### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This customizable app is intended mainly for publishers and marketers. It is also available on [iOS](https://github.com/libreliodev/iOS), [Windows 8](https://github.com/libreliodev/windows8) and in [HTML5](https://github.com/libreliodev/javascript).
 
-If you need to publish dynamic and/or paid contents, you need to set up your own server and develop your own code. You can also opt for Librelio's [paid plans](http://www.librelio.com/index.php#pricing).
+If you need to publish dynamic and/or paid contents, you need to set up your own server and develop your own code. You can also opt for Librelio's [paid plans](http://www.librelio.com/index.html#pricing).
 
 Examples of customized apps published on the app stores are available on www.librelio.com . A good example of iOS app is the [Wind magazine app](https://itunes.apple.com/fr/app/wind-magazine/id433594605?mt=8). 
 


### PR DESCRIPTION
The "paid plans" link redirected to an error page, I've updated it with the proper link. 